### PR TITLE
修正一个处理负数读数时输出数据异常的问题

### DIFF
--- a/AK09918.cpp
+++ b/AK09918.cpp
@@ -105,9 +105,9 @@ AK09918_err_type_t AK09918::getRawData(int32_t* axis_x, int32_t* axis_y, int32_t
     if (!I2Cdev::readBytes(_addr, AK09918_HXL, 8, _buffer)) {
         return AK09918_ERR_READ_FAILED;
     } else {
-        *axis_x = (int32_t)((((int16_t)_buffer[1]) << 8) | _buffer[0]);
-        *axis_y = (int32_t)((((int16_t)_buffer[3]) << 8) | _buffer[2]);
-        *axis_z = (int32_t)((((int16_t)_buffer[5]) << 8) | _buffer[4]);
+        *axis_x = (int16_t)(_buffer[1] << 8 | _buffer[0]);
+        *axis_y = (int16_t)(_buffer[3] << 8 | _buffer[2]);
+        *axis_z = (int16_t)(_buffer[5] << 8 | _buffer[4]);
         if (_buffer[7] & AK09918_HOFL_BIT) {
             return AK09918_ERR_OVERFLOW;
         }


### PR DESCRIPTION
原写法会在传感器给出的数据为负数时，输出错误的结果。如buffer里的两个字节是`0xFE,0xFE`时，输出`65278`而不是`-258`。从而让`getRawData()`输出错误的结果，并在`getData()`接口上输出让人更难以理解的九千左右的数值。
```
// 错误的RawData
M:  1184,  65213,  14 uT
// 修改后的RawData
M:  1188,  -327,  28 uT
```
---
这里的问题在于左移运算符会触发*整形提升*，从而让结果是一个int，哪怕对操作数进行了`(int16_t)`也是无意义的。只能在最后拼合完，转一次`int16_t`，让符号位生效。

PS:
关于运算符：[https://en.cppreference.com/w/cpp/language/operator_arithmetic](https://en.cppreference.com/w/cpp/language/operator_arithmetic)
关于整形提升：[https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion](https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion)